### PR TITLE
Add DataOutput, for OP_RETURN

### DIFF
--- a/bitforge/script/script.py
+++ b/bitforge/script/script.py
@@ -104,6 +104,13 @@ class Script(object):
             [ OP_CHECKMULTISIG ]
         )
 
+    @staticmethod
+    def op_return(data):
+        return Script.compile([
+            OP_RETURN,
+            data
+        ])
+
 
         # OP_0 here for historical reasons, related to a bug in BTC Core
 

--- a/bitforge/transaction/__init__.py
+++ b/bitforge/transaction/__init__.py
@@ -1,3 +1,3 @@
 from input import Input, AddressInput, ScriptInput, MultisigInput
-from output import Output, AddressOutput, ScriptOutput, MultisigOutput
+from output import Output, AddressOutput, ScriptOutput, MultisigOutput, DataOutput
 from transaction import Transaction

--- a/bitforge/transaction/output.py
+++ b/bitforge/transaction/output.py
@@ -66,3 +66,22 @@ class MultisigOutput(ScriptOutput):
     def __new__(cls, amount, pubkeys, min_signatures):
         redeem_script = Script.redeem_multisig(pubkeys, min_signatures)
         return super(MultisigOutput, cls).__new__(cls, amount, redeem_script)
+
+
+class DataOutput(Output):
+
+    class Error(BitforgeError):
+        pass
+
+    class TooMuchData(Error, NumberError):
+        "DataOutputs can carry at most 80 bytes, but {number} were passed in"
+
+
+    def __new__(cls, bytes):
+        if len(bytes) > 80:
+            raise TooMuchData(len(bytes))
+
+        amount = 0
+        script = Script.op_return(bytes)
+
+        return super(DataOutput, cls).__new__(cls, amount, script)

--- a/bitforge/transaction/transaction.py
+++ b/bitforge/transaction/transaction.py
@@ -147,3 +147,7 @@ class Transaction(BaseTransaction):
         lock_time = decode_int(buffer.read(4), big_endian = False)
 
         return Transaction(inputs, outputs, lock_time, version)
+
+    @staticmethod
+    def from_hex(hex):
+        return Transaction.from_bytes(decode_hex(hex))


### PR DESCRIPTION
Can now attach raw data via `OP_RETURN` output scripts, using the `DataOutput` subclass
