### PR TITLE
Verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ out0 = AddressOutput(
 tx = Transaction(inputs = [ in0 ], outputs = [ out0 ])
 
 # 4. Sign the first Input:
-signed_tx = tx.signed([ privkey ], 0)
+signed_tx = tx.sign([ privkey ], 0)
 ```
 
 
@@ -80,7 +80,7 @@ out0 = MultisigOutput(
 tx = Transaction(inputs = [ in0 ], outputs = [ out0 ])
 
 # 4. Sign the first Input:
-signed_tx = tx.signed([ privkey ], 0)
+signed_tx = tx.sign([ privkey ], 0)
 ```
 
 
@@ -234,7 +234,7 @@ type prefix.
 A `Transaction` `Input`. `tx_id` and `txo_index` point to an unspent transaction
 output.
 
-The `Input` class can be instantiated directly, but the `signed()` method will
+The `Input` class can be instantiated directly, but the `sign()` method will
 `raise`. To really work with `Inputs`, you should use or create a subclass.
 These are available out-of-the-box, and described below:
 
@@ -275,7 +275,7 @@ Return a copy of this immutable `Input`, replacing the `script`.
 ##### `.without_script()`
 Return a copy of this immutable `Input`, with an empty (0-byte) `script`.
 
-##### `.signed(privkeys, payload)`
+##### `.sign(privkeys, payload)`
 Return a new `Input`, with the same `tx_id`, `txo_index` and `seq_number`. The
 `script` will be replaced by a version including signatures.
 
@@ -290,7 +290,7 @@ different transaction types. Subclasses provide it.
 ##### `AddressInput(tx_id, txo_index, address, seq_number = FINAL_SEQ_NUMBER)`
 
 A _Pay-to-Pubkey-Hash_ `Input`, that can redeem funds sent to an `Address`. The
-`signed()` method takes a list of `privkeys` with exactly `1` key.
+`sign()` method takes a list of `privkeys` with exactly `1` key.
 
 This is the counterpart of `AddressOutput`.
 
@@ -433,7 +433,7 @@ Serialize this `Transaction` to Bitcoin protocol format.
 Serialize this `Transaction` to Bitcoin protocol format, and return it as a
 hexadecimal string.
 
-##### `signed(privkeys, txi_index)`
+##### `sign(privkeys, txi_index)`
 
 Return a copy of this `Transaction`, where the `Input` at `txi_index` has been
 signed with all `privkeys`.

--- a/README.md
+++ b/README.md
@@ -269,10 +269,10 @@ Serialize this `Input` to Bitcoin protocol format.
 Serialize this `Input` to Bitcoin protocol format, and return it as a hexadecimal
 string.
 
-##### `.with_script(script)`
+##### `.replace_script(script)`
 Return a copy of this immutable `Input`, replacing the `script`.
 
-##### `.without_script()`
+##### `.remove_script()`
 Return a copy of this immutable `Input`, with an empty (0-byte) `script`.
 
 ##### `.sign(privkeys, payload)`

--- a/bitforge/transaction/input.py
+++ b/bitforge/transaction/input.py
@@ -60,11 +60,11 @@ class Input(BaseInput):
     def to_hex(self):
         return encode_hex(self.to_bytes()).decode('utf-8')
 
-    def with_script(self, script):
+    def replace_script(self, script):
         return Input(self.tx_id, self.txo_index, script, self.seq_number)
 
-    def without_script(self):
-        return self.with_script(Script())
+    def remove_script(self):
+        return self.replace_script(Script())
 
     def sign(self, privkeys, payload, sigtype = SIGHASH_ALL):
         # Signing an Input requires knowledge of two things:
@@ -121,7 +121,7 @@ class AddressInput(Input):
             signature = privkeys[0].sign(payload) + chr(sigtype)
         )
 
-        return self.with_script(signed_script)
+        return self.replace_script(signed_script)
 
 
 class ScriptInput(Input):
@@ -140,7 +140,7 @@ class ScriptInput(Input):
             signatures = [ pk.sign(payload) + chr(sigtype) for pk in privkeys ]
         )
 
-        return self.with_script(signed_script)
+        return self.replace_script(signed_script)
 
 
 class MultisigInput(ScriptInput):

--- a/bitforge/transaction/input.py
+++ b/bitforge/transaction/input.py
@@ -66,7 +66,7 @@ class Input(BaseInput):
     def without_script(self):
         return self.with_script(Script())
 
-    def signed(self, privkeys, payload, sigtype = SIGHASH_ALL):
+    def sign(self, privkeys, payload, sigtype = SIGHASH_ALL):
         # Signing an Input requires knowledge of two things:
         #
         # 1. The placeholder Script that will be used in place of the signed one,
@@ -112,7 +112,7 @@ class AddressInput(Input):
 
         return super(AddressInput, cls).__new__(cls, tx_id, txo_index, placeholder_script, seq_number)
 
-    def signed(self, privkeys, payload, sigtype = SIGHASH_ALL):
+    def sign(self, privkeys, payload, sigtype = SIGHASH_ALL):
         if len(privkeys) != 1:
             raise AddressInput.InvalidSignatureCount(1, len(privkeys))
 
@@ -131,7 +131,7 @@ class ScriptInput(Input):
 
         return super(ScriptInput, cls).__new__(cls, tx_id, txo_index, script, seq_number)
 
-    def signed(self, privkeys, payload, sigtype = SIGHASH_ALL):
+    def sign(self, privkeys, payload, sigtype = SIGHASH_ALL):
         # Signing a ScriptInput requires embedding the redeem Script (already
         # set as placeholder in our `script` property by the time this method
         # is invoked) in a standard Pay-to-Script Script.

--- a/bitforge/transaction/transaction.py
+++ b/bitforge/transaction/transaction.py
@@ -87,7 +87,7 @@ class Transaction(BaseTransaction):
     def with_inputs(self, inputs):
         return Transaction(inputs, self.outputs, self.lock_time, self.version)
 
-    def signed(self, privkeys, txi_index, sigtype = SIGHASH_ALL):
+    def sign(self, privkeys, txi_index, sigtype = SIGHASH_ALL):
         # A Transaction Input is signed in 4 steps:
         #   1. Create a simplified Transaction without data from other Inputs
         #   2. Sign the simplified Transaction data, discard it, keep the signature
@@ -120,7 +120,7 @@ class Transaction(BaseTransaction):
         # PrivateKeys. Each Input subclass knows how to handle this process. The
         # signed Input will loose the placeholder Script and get a real one.
 
-        signed_input = self.inputs[txi_index].signed(privkeys, payload, sigtype)
+        signed_input = self.inputs[txi_index].sign(privkeys, payload, sigtype)
 
         # 4. Build a new Transaction, restoring the other Input Scripts, and
         # setting this Input to the new version including the signature:

--- a/bitforge/transaction/transaction.py
+++ b/bitforge/transaction/transaction.py
@@ -84,7 +84,7 @@ class Transaction(BaseTransaction):
     def get_id(self):
         return encode_hex(self.get_id_bytes())
 
-    def with_inputs(self, inputs):
+    def replace_inputs(self, inputs):
         return Transaction(inputs, self.outputs, self.lock_time, self.version)
 
     def sign(self, privkeys, txi_index, sigtype = SIGHASH_ALL):
@@ -102,11 +102,11 @@ class Transaction(BaseTransaction):
         # there already, manually placed or auto-created by Input subclasses.
 
         simplified_inputs = (
-            input.without_script() if i != txi_index else input
+            input.remove_script() if i != txi_index else input
             for i, input in enumerate(self.inputs)
         )
 
-        simplified_transaction = self.with_inputs(simplified_inputs)
+        simplified_transaction = self.replace_inputs(simplified_inputs)
 
         # 2. Write the payload we're going to sign, which is the serialization
         # of the simplified transaction, with an extra 4 bytes for the signature
@@ -130,7 +130,7 @@ class Transaction(BaseTransaction):
             for i, input in enumerate(self.inputs)
         )
 
-        return self.with_inputs(new_inputs) # voila!
+        return self.replace_inputs(new_inputs) # voila!
 
 
     @staticmethod


### PR DESCRIPTION
I revised some method names. In particular:
- I abandoned past-tense verbs (`signed()` changed to `sign()`)
- I stopped using `with_` to indicate copies of immutable objects

More methods are coming, and both are problematic patterns.
